### PR TITLE
Add general Exception for Exception

### DIFF
--- a/src/DeezerAPI.php
+++ b/src/DeezerAPI.php
@@ -121,6 +121,18 @@ class DeezerAPI
         $response = $this->request->api('GET', '/track/' . $trackId);
         return $response['body'];
     }
+
+    /**
+     * Get a single album
+     * 
+     * @param integer $albumId
+     * @return array
+     */
+    public function getAlbum($albumId)
+    {
+        $response = $this->request->api('GET', '/album/' . $albumId);
+        return $response['body'];
+    }
     
     /**
      * Get all playlists for the authenticated user

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,7 @@
+<?php
+namespace DeezerAPI\Exception;
+
+class Exception extends \Exception
+{
+
+}


### PR DESCRIPTION
The exception 'Exception' was not defined. So, when I received this exception I was presented with:

`PHP Fatal error:  Class 'DeezerAPI\Exception\Exception' not found in /var/www/html/project/vendor/clemfromspace/deezer-php-api/src/Request.php on line 84`

Adding this extra Exception class, this turns into a much more understandable error message:

`[DeezerAPI\Exception\Exception]
Quota limit exceeded`
